### PR TITLE
Do not replace packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,6 @@
         "psr-0" : { "" : "src/" }
     },
 
-    "replace" : {
-        "jms/serializer" : "*"
-    },
-
     "require" : {
         "php"                                  : ">=5.3.3",
         "henrikbjorn/flint"                    : "~1.2",


### PR DESCRIPTION
Don't ever replace packages you don't own. It will cause composer
to fall back to _your_ package if it cannot find a suitable
version of the original one.

We've had numerous breakages due to this, where random people
were replacing zendframework or symfony components and thus
borked the internet.

Side note: Yes, packagist really should prevent you from doing
stupid things like this as it is non-obvious. Unfortunately it
currently does not.
